### PR TITLE
Update http.rb - fix empty query

### DIFF
--- a/lib/cocaine/server/http.rb
+++ b/lib/cocaine/server/http.rb
@@ -19,7 +19,8 @@ module Cocaine::Http
       @ch.callback { |msg|
         @method, url, @version, headers, @body = MessagePack::unpack msg
         @headers = Hash[headers]
-        @query = CGI.parse(URI.parse(url).query)
+        tmp_query = URI.parse(url).query
+        @query = tmp_query == nil ? {} : CGI.parse(tmp_query)
         ch.trigger self
       }.errback { |err|
         ch.error err


### PR DESCRIPTION
If we got empty query (without "?") CGI.parse fails with error (unknown split function on nil).
