### PR TITLE
Allow override locator endpoint before creating Service object.

### DIFF
--- a/lib/cocaine/client/service.rb
+++ b/lib/cocaine/client/service.rb
@@ -58,7 +58,13 @@ end
 
 
 class Cocaine::Locator < Cocaine::AbstractService
-  def initialize(host='localhost', port=10053)
+  @default_host = 'localhost'
+  @default_port = 10053
+  class << self
+    attr_accessor :default_host, :default_port
+  end
+
+  def initialize(host=self.class.default_host, port=self.class.default_port)
     @name = 'locator'
     @host = host
     @port = port


### PR DESCRIPTION
Example:
Cocaine::Locator.default_host = '192.168.1.1'
Cocaine::Locator.default_port = 10053
service = Cocaine::Synchrony::Service.new 'DummyService'
